### PR TITLE
Update README enclosure example to correct length

### DIFF
--- a/rss-in-json/README.md
+++ b/rss-in-json/README.md
@@ -20,7 +20,7 @@ If an element has a value and no attributes it's represented as a property in th
 
 <pre>"enclosure": {
    "url": "http://www.scripting.com/mp3s/weatherReportSuite.mp3",
-   "length": "12216320",
+   "length": 12216320,
    "type": "audio/mpeg"
    }
 </pre>


### PR DESCRIPTION
Enclosure length should be a number, not a string